### PR TITLE
Added the no-cache header to the http request in getIp()

### DIFF
--- a/DuckDNSClient/src/duckdns.java
+++ b/DuckDNSClient/src/duckdns.java
@@ -322,7 +322,7 @@ String url = "http://checkip.amazonaws.com";
 String ip = "";
 
 try {
-doc = Jsoup.connect(url).ignoreHttpErrors(true).ignoreContentType(true).timeout(10 * 1000).get();
+doc = Jsoup.connect(url).header("Cache-Control", "no-cache").ignoreHttpErrors(true).ignoreContentType(true).timeout(10 * 1000).get();
 ip = doc.text();
 } catch (IOException e) {
 e.printStackTrace();


### PR DESCRIPTION
Without the flag, intermediate caches may cache an ip from a previous
request and thus return the wrong ip address.