### PR TITLE
Trim user input to avoid errors when they pasting the token.

### DIFF
--- a/DuckDNSClient/src/duckdns.java
+++ b/DuckDNSClient/src/duckdns.java
@@ -180,8 +180,8 @@ settingsItem.addActionListener(new ActionListener() {
  if (a == JOptionPane.OK_OPTION) {
 
  if (domainField.getText().length() > 0 && tokenField.getText().length() > 0) {
- prefs.put("domain", domainField.getText().replace(".duckdns.org", ""));
- prefs.put("token", tokenField.getText());
+ prefs.put("domain", domainField.getText().trim().replace(".duckdns.org", ""));
+ prefs.put("token", tokenField.getText().trim());
  prefs.put("refresh", minuteField.getSelectedItem().toString());
  String ip = getip();
  //  prefs.put("oldipaddress", ip);


### PR DESCRIPTION
Spent half an hour troubleshooting the error message "Unable to reach DuckDNS.org!" when there was a blank space at the end of my token that was corrupting the final URL.